### PR TITLE
feat: add should to boolean prop naming

### DIFF
--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -25,9 +25,9 @@ const reactConfig = {
     "react/boolean-prop-naming": [
       "error",
       {
-        rule: "^(is|has|should)[A-Z]([A-Za-z0-9]?)+",
+        rule: "^(is|has|should|can|did|will)[A-Z]([A-Za-z0-9]?)+",
         message:
-          "It is better if your prop ({{ propName }}) starts with `is`, `has`, or `should`",
+          "It is better if your prop ({{ propName }}) starts with `is`, `has`, `should`, `can`, `did`, or `will`",
       },
     ],
     "react/function-component-definition": [

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -25,9 +25,9 @@ const reactConfig = {
     "react/boolean-prop-naming": [
       "error",
       {
-        rule: "^(is|has)[A-Z]([A-Za-z0-9]?)+",
+        rule: "^(is|has|should)[A-Z]([A-Za-z0-9]?)+",
         message:
-          "It is better if your prop ({{ propName }}) starts with `is` or `has`",
+          "It is better if your prop ({{ propName }}) starts with `is`, `has`, or `should`",
       },
     ],
     "react/function-component-definition": [


### PR DESCRIPTION
# Description
- Add `should` to React boolean prop naming