### PR TITLE
feat: add extra rules to naming convention

### DIFF
--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -33,6 +33,15 @@ const baseConfig = {
         ],
         format: ["strictCamelCase"],
       },
+      // Allow ITestType
+      {
+        "selector": ["typeLike"],
+        "format": ["PascalCase"],
+        "filter": {
+          "regex": "^I[A-Z]",
+          "match": true
+        }
+      },
       // PascalCase
       {
         selector: ["typeLike"],
@@ -48,6 +57,16 @@ const baseConfig = {
       {
         selector: ["enumMember"],
         format: ["UPPER_CASE"],
+      },
+      // Allow StackNavigator, TestContext, etc. as PascalCase
+      {
+        "selector": ["variable"],
+        "modifiers": ["const"],
+        "format": ["StrictPascalCase"],
+        "filter": {
+          "regex": "(.*)(Navigator|Context|Screen(s?))",
+          "match": true
+        }
       },
       {
         selector: ["variable"],


### PR DESCRIPTION
# Description
- Allow `<whatever>Navigation`, `<whatever>Context`, `<whatever>Screen`, and `<whatever>Screens` in naming convention rule
- Allow `ITypeName` for types