### PR TITLE
ci: rename main to master

### DIFF
--- a/.github/workflows/base-release-please.yml
+++ b/.github/workflows/base-release-please.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
     paths:
       - "packages/base/**"
 

--- a/.github/workflows/react-native-release-please.yml
+++ b/.github/workflows/react-native-release-please.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
     paths:
       - "packages/react-native/**"
 

--- a/.github/workflows/react-release-please.yml
+++ b/.github/workflows/react-release-please.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
     paths:
       - "packages/react/**"
 


### PR DESCRIPTION
# Description
- Fix github actions not firing due to looking for changes on `main` not `master` (fuck you GitHub)