### PR TITLE
feat: dont match hooks for context naming

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plaidypus-dev/eslint-config-base",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The base eslint config for Plaidypus",
   "author": "David Shefcik <dshefcik@plaidypus.com>",
   "homepage": "https://github.com/PlaidypusDev/eslint-config#readme",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plaidypus-dev/eslint-config-base",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The base eslint config for Plaidypus",
   "author": "David Shefcik <dshefcik@plaidypus.com>",
   "homepage": "https://github.com/PlaidypusDev/eslint-config#readme",

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -64,7 +64,7 @@ const baseConfig = {
         "modifiers": ["const"],
         "format": ["StrictPascalCase"],
         "filter": {
-          "regex": "^((?!use).)*(Navigator|Context|Screen(s?))$",
+          "regex": "^[^use](.*)(Navigator|Context|Screen(s?))$",
           "match": true
         }
       },

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -64,7 +64,7 @@ const baseConfig = {
         "modifiers": ["const"],
         "format": ["StrictPascalCase"],
         "filter": {
-          "regex": "(.*)(Navigator|Context|Screen(s?))",
+          "regex": "^((?!use).)*(Navigator|Context|Screen(s?))$",
           "match": true
         }
       },


### PR DESCRIPTION
# Description
- Don't match hooks (starts with `use`) for context naming linting