### PR TITLE
feat: move naming rules to react package

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plaidypus-dev/eslint-config-base",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "The base eslint config for Plaidypus",
   "author": "David Shefcik <dshefcik@plaidypus.com>",
   "homepage": "https://github.com/PlaidypusDev/eslint-config#readme",

--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -66,16 +66,6 @@ const baseConfig = {
         selector: ["enumMember"],
         format: ["UPPER_CASE"],
       },
-      // Allow StackNavigator, TestContext, etc. as PascalCase
-      {
-        "selector": ["variable"],
-        "modifiers": ["const"],
-        "format": ["StrictPascalCase"],
-        "filter": {
-          "regex": "^[^use](.*)(Navigator|Context|Screen(s?))$",
-          "match": true
-        }
-      },
       {
         selector: ["variable"],
         modifiers: ["const"],

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plaidypus-dev/eslint-config-react",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The React eslint config for Plaidypus",
   "keywords": [],
   "author": "David Shefcik <dshefcik@plaidypus.com>",

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -42,6 +42,24 @@ const reactConfig = {
     "react/jsx-boolean-value": "warn",
     "react/jsx-pascal-case": "error",
     "react/react-in-jsx-scope": "off",
+    // PascalCase for naming React specific constants
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": ["variable"],
+        "modifiers": ["const"],
+        "format": ["StrictPascalCase"],
+        "filter": {
+          "regex": "^[^use](.*)(Navigator|Context|Screen(s?))$",
+          "match": true
+        }
+      },
+      {
+        selector: ["variable"],
+        modifiers: ["const"],
+        format: ["strictCamelCase", "UPPER_CASE"],
+      },
+    ]
   },
 };
 


### PR DESCRIPTION
# Description
- Move PascalCase constant rule to React constants to the React package
- Have to move the default const variable to the React package as well so it gets applied correctly