### PR TITLE
feat: private class members underscore prefix

### DIFF
--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -35,6 +35,12 @@ const baseConfig = {
         ],
         format: ["strictCamelCase"],
       },
+      {
+        "selector": "memberLike",
+        "modifiers": ["private"],
+        "format": ["camelCase"],
+        "leadingUnderscore": "require"
+      },
       // Allow ITestType
       {
         "selector": ["typeLike"],


### PR DESCRIPTION
# Description
- Require private class members have a leading underscore. Since we use the `private` modifier the class member has to be declared with the private keyword