### PR TITLE
fix: allow ref abbreviation

### DIFF
--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -101,6 +101,7 @@ const baseConfig = {
           props: false,
           args: false,
           params: false,
+          ref: false
         },
       },
     ],


### PR DESCRIPTION
# Description
- Allow `ref` abbreviation