### PR TITLE
feat: explicit member accessibility

### DIFF
--- a/packages/base/src/index.js
+++ b/packages/base/src/index.js
@@ -94,6 +94,9 @@ const baseConfig = {
         format: null,
       },
     ],
+    // Class member accessibility
+    "@typescript-eslint/explicit-member-accessibility": ["error"],
+    // Unicorn
     "unicorn/prevent-abbreviations": [
       "error",
       {


### PR DESCRIPTION
- Set the [explicit member accessibility rule](https://typescript-eslint.io/rules/explicit-member-accessibility/) to show an error if a class member is missing the `private`, `public` or `protected` keyword