### PR TITLE
feat!: make exhaustive deps show an error

### DIFF
--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -42,6 +42,8 @@ const reactConfig = {
     "react/jsx-boolean-value": "warn",
     "react/jsx-pascal-case": "error",
     "react/react-in-jsx-scope": "off",
+    // Hooks
+    "react-hooks/exhaustive-deps": "error",
     // PascalCase for naming React specific constants
     "@typescript-eslint/naming-convention": [
       "error",


### PR DESCRIPTION
- Make exhaustive dependencies for hooks show an error instead of a warning when a dependency is missing